### PR TITLE
ex_stage: Fix type of `C_DIV`

### DIFF
--- a/rtl/riscv_ex_stage.sv
+++ b/rtl/riscv_ex_stage.sv
@@ -418,7 +418,7 @@ module riscv_ex_stage
            assign {fpu_vec_op, fpu_op_mod, fpu_op} = apu_op_i;
            assign {fpu_int_fmt, fpu_src_fmt, fpu_dst_fmt, fp_rnd_mode} = apu_flags_i;
 
-           localparam C_DIV = FP_DIVSQRT ? fpnew_pkg::MERGED : fpnew_pkg::DISABLED;
+           localparam fpnew_pkg::unit_type_t C_DIV = FP_DIVSQRT ? fpnew_pkg::MERGED : fpnew_pkg::DISABLED;
 
            logic FPU_ready_int;
 


### PR DESCRIPTION
Without this explicit type annotation, Vivado 2020.2 [fails to synthesize this code](https://pulp-platform.org/community/showthread.php?tid=252&pid=722#pid722) -- although the SystemVerilog standard states "A parameter declaration with no type or range specification shall default to the type and range of the final value assigned to the parameter [...]" (Section 6.20.2 in IEEE 1800-2012).